### PR TITLE
Added proper order for CIPHER IIS10/Windows2016, Minimum Protocol to …

### DIFF
--- a/templates/waf.json
+++ b/templates/waf.json
@@ -156,6 +156,37 @@
           "disabledSslProtocols": [
             "TLSv1_0",
             "TLSv1_1"
+          ],
+          "cipherSuites": [
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384_P521",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384_P384",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P521",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P384",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P256",
+            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P521",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P384",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256_P521",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256_P384",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256_P256",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA_P521",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA_P384",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA_P256",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA_P521",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA_P384",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA_P256",
+            "TLS_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_RSA_WITH_AES_256_CBC_SHA256",
+            "TLS_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
+          ],
+          "minProtocolVersion": [
+            "TLSv1_2"
           ]
         },
         "frontendIPConfigurations": [


### PR DESCRIPTION
…TLS1.2

To resolve: https://tools.hmcts.net/jira/browse/CNP-480

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
