### PR TITLE
Revert "Added proper order for CIPHER IIS10/Windows2016, Minimum Protocol to …"

### DIFF
--- a/templates/waf.json
+++ b/templates/waf.json
@@ -156,37 +156,6 @@
           "disabledSslProtocols": [
             "TLSv1_0",
             "TLSv1_1"
-          ],
-          "cipherSuites": [
-            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384_P521",
-            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384_P384",
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P521",
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P384",
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256_P256",
-            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P521",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P384",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256_P521",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256_P384",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256_P256",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA_P521",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA_P384",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA_P256",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA_P521",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA_P384",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA_P256",
-            "TLS_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_RSA_WITH_AES_256_CBC_SHA256",
-            "TLS_RSA_WITH_AES_128_CBC_SHA256",
-            "TLS_RSA_WITH_AES_256_CBC_SHA",
-            "TLS_RSA_WITH_AES_128_CBC_SHA",
-            "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
-          ],
-          "minProtocolVersion": [
-            "TLSv1_2"
           ]
         },
         "frontendIPConfigurations": [


### PR DESCRIPTION
This change is not correct and has broken the template - A re-write of the policy section is needed as well as an upgrade in the API version to achieve the minProtocolVersion setting.