### PR TITLE
Add ip fqdn output using data source

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,7 @@
 data "azurerm_public_ip" "waf_public_ip" {
   depends_on = ["azurerm_template_deployment.waf"]
   
-  name                = "${lookup(element(local.frontendIPConfigurations, 0), "publicIpName")}"
+  name                = "${lookup(local.frontendIPConfigurations[0], "publicIpName")}"
   resource_group_name = "${var.resourcegroupname}"
 }
 


### PR DESCRIPTION
The module needs to output the FQDN for the public IP address as this will be needed to set up the endpoints within the Traffic Manager. 