### PR TITLE
Allow config of Firewall max file size and request body

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -219,6 +219,8 @@ resource "azurerm_template_deployment" "waf" {
     wafMode           = "Prevention"
     wafEnabled        = "${var.wafEnabled}"
     wafRuleSetType    = "${var.wafRuleSetType}"
+    wafMaxRequestBodySize = "${var.wafMaxRequestBodySize}"
+    wafFileUploadLimit = "${var.wafFileUploadLimit}"
     sslPolicy         = "${var.sslPolicy}"
     wafRuleSetVersion = "${var.wafRuleSetVersion}"
     baseUri = "${azurerm_storage_account.templateStore.primary_blob_endpoint}${azurerm_storage_container.templates.name}/"

--- a/templates/appGatewayDeploy.json
+++ b/templates/appGatewayDeploy.json
@@ -62,6 +62,12 @@
     },
     "logAnalyticsWorkspaceId": {
       "type": "string"
+    },
+    "wafMaxRequestBodySize": {
+      "type": "string"
+    },
+    "wafFileUploadLimit": {
+      "type": "string"
     }
   },
   "variables": {},
@@ -83,7 +89,7 @@
       }
     },
     {
-      "apiVersion": "2017-06-01",
+      "apiVersion": "2018-11-01",
       "name": "[parameters('appGatewaySettings').name]",
       "type": "Microsoft.Network/applicationGateways",
       "location": "[parameters('location')]",
@@ -119,7 +125,9 @@
                 931130
               ]
             }
-          ]
+          ],
+          "maxRequestBodySizeInKb": "[parameters('wafMaxRequestBodySize')]",
+          "fileUploadLimitInMb": "[parameters('wafFileUploadLimit')]"
         },
         "sslPolicy": {
           "policyType": "Custom",

--- a/templates/appGatewayLoader.json
+++ b/templates/appGatewayLoader.json
@@ -72,6 +72,12 @@
     "wafRuleSetVersion": {
       "type": "string"
     },
+    "wafMaxRequestBodySize": {
+      "type": "string"
+    },
+    "wafFileUploadLimit": {
+      "type": "string"
+    },
     "sslPolicy": {
       "type": "string"
     },
@@ -236,6 +242,12 @@
           },
           "wafRuleSetVersion": {
             "value": "[parameters('wafRuleSetVersion')]"
+          },
+          "wafMaxRequestBodySize": {
+            "value": "[parameters('wafMaxRequestBodySize')]"
+          },
+          "wafFileUploadLimit": {
+            "value": "[parameters('wafFileUploadLimit')]"
           },
           "sslPolicy": {
             "value": "[parameters('sslPolicy')]"

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,16 @@ variable "wafRuleSetVersion" {
   default = "3.0"
 }
 
+variable "wafMaxRequestBodySize" {
+  description = "Maximum request body size in kB for WAF"
+  default = "128"
+}
+
+variable "wafFileUploadLimit" {
+  description = "Maximum file upload size in MB for WAF"
+  default = "100"
+}
+
 variable "sslPolicy" {
   default = "AppGwSslPolicy20170401S"
 }


### PR DESCRIPTION
Default values are set to defaults on Azure.  See
https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-waf-configuration#waf-request-size-limits

This change allows some control over these values.  Essential for being able to control file upload sizes in Document Store.
