### PR TITLE
PAY-2415: Enable WAF configuration for ITHC

### DIFF
--- a/templates/appGatewayDeploy.json
+++ b/templates/appGatewayDeploy.json
@@ -124,6 +124,15 @@
               "rules":[
                 931130
               ]
+            },
+            {
+              "ruleGroupName": "REQUEST-942-APPLICATION-ATTACK-SQLI",
+              "rules":[
+                942200,
+                942260,
+                942340,
+                942370
+              ]
             }
           ],
           "maxRequestBodySizeInKb": "[parameters('wafMaxRequestBodySize')]",


### PR DESCRIPTION
We wanted to disable below set of rules, to run paybubble application on prevention mode